### PR TITLE
renames and refactors

### DIFF
--- a/cogs/mission_data_cog.py
+++ b/cogs/mission_data_cog.py
@@ -1,7 +1,7 @@
 from discord.ext import tasks, commands
-from drg import daily_data
+from drg import missions
 
-class DailyDataCog(commands.Cog):
+class MissionDataCog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.daily_data = None
@@ -12,7 +12,7 @@ class DailyDataCog(commands.Cog):
     
     @tasks.loop(hours=24)
     async def refresh_daily_data(self):
-        self.daily_data = daily_data.DailyData()
+        self.daily_data = missions.MissionData()
     
     @commands.command()
     async def current(self, ctx, season: str = 's0'):
@@ -80,4 +80,4 @@ class DailyDataCog(commands.Cog):
         await ctx.send(str(self.daily_data.daily_deal))
 
 async def setup(bot):
-    await bot.add_cog(DailyDataCog(bot))
+    await bot.add_cog(MissionDataCog(bot))

--- a/drg/deep_dive.py
+++ b/drg/deep_dive.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 import requests
 import json
 
-domain_url = 'https://doublexp.net'
+from drg import utils
 
 DEEP_DIVE_REFRESH_DAY = 3
 DEEP_DIVE_REFRESH_HOUR = 11
@@ -15,7 +15,7 @@ class DeepDiveData:
         if refresh_time > time_now:
             refresh_time = refresh_time - timedelta(weeks=1)
 
-        url = f'{domain_url}/static/json/DD_{refresh_time.strftime("%Y-%m-%dT%H-%M-%SZ")}.json'
+        url = f'{utils.DOMAIN_URL}/static/json/DD_{refresh_time.strftime("%Y-%m-%dT%H-%M-%SZ")}.json'
         r = requests.get(url)
         data = json.loads(r.content)
 

--- a/drg/utils.py
+++ b/drg/utils.py
@@ -1,0 +1,2 @@
+DOMAIN_URL = 'https://doublexp.net'
+UNIQUELY_IDENTIFYING_COLUMNS = ['Season', 'TimeStamp', 'Mission ID']


### PR DESCRIPTION
* Change language from "daily data" to "mission data", since daily is a misnomer; the data is refreshed daily, but contains up to 48 hours' worth of mission data (missions refresh every 30 minutes)
* Move some config variables like the API domain URL to a separate file that can be shared by deep dive and mission data modules